### PR TITLE
Clear static interface variables at startup

### DIFF
--- a/FishNet/Plugins/FishyEOS/FishyEOS.cs
+++ b/FishNet/Plugins/FishyEOS/FishyEOS.cs
@@ -114,6 +114,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
         public override void Initialize(NetworkManager networkManager, int transportIndex)
         {
             base.Initialize(networkManager, transportIndex);
+            EOS.ClearCachedInterface();
             _client.Initialize(this);
             _clientHost.Initialize(this);
             _server.Initialize(this);

--- a/FishNet/Plugins/FishyEOS/Util/EOS.cs
+++ b/FishNet/Plugins/FishyEOS/Util/EOS.cs
@@ -23,6 +23,15 @@ namespace FishNet.Plugins.FishyEOS.Util
 
         public static ProductUserId LocalProductUserId => GetCachedConnectInterface()?.GetLoggedInUserByIndex(0);
 
+        public static void ClearCachedInterface()
+        {
+            _cachedAuthInterface = null;
+            _cachedConnectInterface = null;
+            _cachedP2PInterface = null;
+            _eosManager = null;
+            _createdOrGotPlatformInterface = false;
+        }
+
         public static PlatformInterface GetPlatformInterface()
         {
             if (_createdOrGotPlatformInterface) return EOSManager.Instance?.GetEOSPlatformInterface();


### PR DESCRIPTION
Prevents fast (without domain reload) play mode from crashing.