### PR TITLE
Fixed compatibility with EOS for Unity 2.3.0

### DIFF
--- a/FishNet/Plugins/FishyEOS/com.etdofresh.fishyeos.asmdef
+++ b/FishNet/Plugins/FishyEOS/com.etdofresh.fishyeos.asmdef
@@ -4,7 +4,7 @@
     "references": [
         "GUID:7c88a4a7926ee5145ad2dfa06f454c67",
         "GUID:be1f6e9efffcfce41aeb5c2f4c27cf75",
-        "GUID:2ced8f3cc58f63843bc26c7591a35628"
+        "GUID:3a63500f0eef43a438c0553491f7c5da"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/FishNet/Plugins/FishyEOS/com.etdofresh.fishyeos.asmdef.meta
+++ b/FishNet/Plugins/FishyEOS/com.etdofresh.fishyeos.asmdef.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 55ca1783e93a0624e8610db1ff979c07
+guid: 3ffa36a516123d246bf055e4310351a6
 AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 


### PR DESCRIPTION
EOS for Unity was updated, and it broke compatibility; now that it is fixed, the plugin can function.

What changed:
Referenced "com.playeverywhere.eos.core" instead of "com.playeverywhere.eos" in the com.etdofresh.fishyeos.asmdef file.