### PR TITLE
Fix All clients dropping connection when a single client disconnects + 'EOSManager' does not contain a definition for 'ConfigFileName'

### DIFF
--- a/FishNet/Plugins/FishyEOS/Util/EOS.cs
+++ b/FishNet/Plugins/FishyEOS/Util/EOS.cs
@@ -42,7 +42,7 @@ namespace FishNet.Plugins.FishyEOS.Util
             UnityEngine.Object.DontDestroyOnLoad(gameObject);
             _eosManager = gameObject.AddComponent<EOSManager>();
 #if !UNITY_EDITOR && !(UNITY_STANDALONE_WIN)
-            EOSManager.Instance?.Init(_eosManager, EOSManager.ConfigFileName);
+            EOSManager.Instance?.Init(_eosManager, EOSPackageInfo.ConfigFileName);
 #endif
             return PlatformInterface;
         }
@@ -58,7 +58,7 @@ namespace FishNet.Plugins.FishyEOS.Util
             UnityEngine.Object.DontDestroyOnLoad(gameObject);
             _eosManager = gameObject.AddComponent<EOSManager>();
 #if !UNITY_EDITOR && !(UNITY_STANDALONE_WIN)
-            EOSManager.Instance?.Init(_eosManager, EOSManager.ConfigFileName);
+            EOSManager.Instance?.Init(_eosManager, EOSPackageInfo.ConfigFileName);
 #endif
             return _eosManager;
         }


### PR DESCRIPTION
- https://github.com/ETdoFresh/FishyEOS/issues/12
- https://github.com/ETdoFresh/FishyEOS/issues/8

**Pending Issue:**
1) Player connects to server;
2) Player disconnects due to an error;
3) Player reconnects, but its previous connection is still active
The case should be properly handled: the previous connection should be removed immediately (before timeout) and properly replaced by the new one.
This issue probably already exist in the current FishyEOS version
