### PR TITLE
New logging api

### DIFF
--- a/FishNet/Plugins/FishyEOS/Core/ClientPeer.cs
+++ b/FishNet/Plugins/FishyEOS/Core/ClientPeer.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections;
 using Epic.OnlineServices;
 using Epic.OnlineServices.P2P;
-using FishNet.Managing.Logging;
+using FishNet.Managing;
 using FishNet.Plugins.FishyEOS.Util;
 using UnityEngine;
 
@@ -69,17 +69,13 @@ namespace FishNet.Transporting.FishyEOSPlugin
                 yield return _transport.AuthConnectData.Connect(out var authDataLogin);
                 if (authDataLogin.loginCallbackInfo?.ResultCode != Result.Success)
                 {
-                    if (_transport.NetworkManager.CanLog(LoggingType.Error))
-                        Debug.LogError(
-                            $"[ClientPeer] Failed to authenticate with EOS Connect. {authDataLogin.loginCallbackInfo?.ResultCode}");
+                    _transport.NetworkManager.LogError($"[ClientPeer] Failed to authenticate with EOS Connect. {authDataLogin.loginCallbackInfo?.ResultCode}");
                     base.SetLocalConnectionState(LocalConnectionState.Stopped, true);
                     yield break;
                 }
             }
 
-            if (_transport.NetworkManager.CanLog(LoggingType.Common))
-                Debug.Log(
-                    $"[ClientPeer] Authenticated with EOS Connect. {EOS.LocalProductUserId}");
+            _transport.NetworkManager.Log($"[ClientPeer] Authenticated with EOS Connect. {EOS.LocalProductUserId}");
 
             // Attempt to connect to Server Remote User Id P2P connection...
             _localUserId = EOS.LocalProductUserId;
@@ -120,9 +116,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
             if (acceptConnectionResult != Result.Success)
             {
                 base.SetLocalConnectionState(LocalConnectionState.Stopped, false);
-                if (_transport.NetworkManager.CanLog(LoggingType.Error))
-                    Debug.LogError(
-                        $"[{nameof(ClientPeer)}] AcceptConnection failed with error: {acceptConnectionResult}");
+                _transport.NetworkManager.LogError($"[{nameof(ClientPeer)}] AcceptConnection failed with error: {acceptConnectionResult}");
                 StopConnection();
                 yield break;
             }
@@ -153,8 +147,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
 
             if (result == Result.Success) return true;
 
-            if (_transport.NetworkManager.CanLog(LoggingType.Error))
-                Debug.LogWarning($"[ClientPeer] Failed to close connection. Error: {result}");
+            _transport.NetworkManager.LogError($"[ClientPeer] Failed to close connection. Error: {result}");
             return false;
         }
 
@@ -168,8 +161,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
 
             _connectionType = data.ConnectionType.ToString();
             base.SetLocalConnectionState(LocalConnectionState.Started, false);
-            if (_transport.NetworkManager.CanLog(LoggingType.Common))
-                Debug.Log($"[ClientPeer] Connection to server established. ConnectionType: {_connectionType}");
+            _transport.NetworkManager.Log($"[ClientPeer] Connection to server established. ConnectionType: {_connectionType}");
         }
 
         /// <summary>
@@ -183,8 +175,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
             if (_peerConnectionClosedEventHandle.HasValue)
                 EOS.GetCachedP2PInterface().RemoveNotifyPeerConnectionClosed(_peerConnectionClosedEventHandle.Value);
 
-            if (_transport.NetworkManager.CanLog(LoggingType.Common))
-                Debug.Log($"[ClientPeer] Connection to server closed.");
+            _transport.NetworkManager.Log($"[ClientPeer] Connection to server closed.");
             StopConnection();
         }
 
@@ -221,14 +212,12 @@ namespace FishNet.Transporting.FishyEOSPlugin
             var result = Send(_localUserId, _remoteUserId, _socketId, channelId, segment);
             if (result == Result.NoConnection || result == Result.InvalidParameters)
             {
-                if (_transport.NetworkManager.CanLog(LoggingType.Common))
-                    Debug.Log($"[ClientPeer] Connection to server was lost.");
+                _transport.NetworkManager.Log($"[ClientPeer] Connection to server was lost.");
                 StopConnection();
             }
             else if (result != Result.Success)
             {
-                if (_transport.NetworkManager.CanLog(LoggingType.Error))
-                    Debug.LogError($"[ClientPeer] Could not send: {result.ToString()}");
+                _transport.NetworkManager.LogError($"[ClientPeer] Could not send: {result}");
             }
         }
 
@@ -238,8 +227,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
         private void OnQueryNATType(ref OnQueryNATTypeCompleteInfo data)
         {
             _natType = data.NATType.ToString();
-            if (_transport.NetworkManager.CanLog(LoggingType.Common))
-                Debug.Log($"[{nameof(ClientPeer)}] NATType: {_natType}");
+            _transport.NetworkManager.Log($"[{nameof(ClientPeer)}] NATType: {_natType}");
         }
     }
 }

--- a/FishNet/Plugins/FishyEOS/Core/CommonPeer.cs
+++ b/FishNet/Plugins/FishyEOS/Core/CommonPeer.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Epic.OnlineServices;
 using Epic.OnlineServices.P2P;
-using FishNet.Managing.Logging;
+using FishNet.Managing;
 using FishNet.Plugins.FishyEOS.Util;
 using UnityEngine;
 
@@ -131,9 +131,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
 
             if (getPacketSizeResult != Result.Success)
             {
-                if (_transport.NetworkManager.CanLog(LoggingType.Error))
-                    Debug.LogError(
-                        $"[{nameof(ClientPeer)}] GetNextReceivedPacketSize failed with error: {getPacketSizeResult}");
+                _transport.NetworkManager.LogError($"[{nameof(ClientPeer)}] GetNextReceivedPacketSize failed with error: {getPacketSizeResult}");
                 return false;
             }
 
@@ -148,9 +146,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
             channel = (Channel)channelByte;
             if (receivePacketResult != Result.Success)
             {
-                if (_transport.NetworkManager.CanLog(LoggingType.Error))
-                    Debug.LogError(
-                        $"[{nameof(ClientPeer)}] ReceivePacket failed with error: {receivePacketResult}");
+                _transport.NetworkManager.LogError($"[{nameof(ClientPeer)}] ReceivePacket failed with error: {receivePacketResult}");
                 return false;
             }
 
@@ -167,8 +163,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
                 EOS.GetCachedP2PInterface().GetPacketQueueInfo(ref getPacketQueueInfoOptions, out var packetQueueInfo);
             if (getPacketQueueResult != Result.Success)
             {
-                if (_transport.NetworkManager.CanLog(LoggingType.Error))
-                    Debug.LogError($"[CommonSocket] Failed to get packet queue info with error {getPacketQueueResult}");
+                _transport.NetworkManager.LogError($"[CommonSocket] Failed to get packet queue info with error {getPacketQueueResult}");
                 return 0;
             }
 

--- a/FishNet/Plugins/FishyEOS/Core/ServerPeer.cs
+++ b/FishNet/Plugins/FishyEOS/Core/ServerPeer.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Epic.OnlineServices;
 using Epic.OnlineServices.P2P;
-using FishNet.Managing.Logging;
+using FishNet.Managing;
 using FishNet.Plugins.FishyEOS.Util;
 using UnityEngine;
 
@@ -87,16 +87,13 @@ namespace FishNet.Transporting.FishyEOSPlugin
                 yield return _transport.AuthConnectData.Connect(out var authDataLogin);
                 if (authDataLogin.loginCallbackInfo?.ResultCode != Result.Success)
                 {
-                    if (_transport.NetworkManager.CanLog(LoggingType.Error))
-                        Debug.LogError(
-                            $"[ServerPeer] Failed to authenticate with EOS Connect. {authDataLogin.loginCallbackInfo?.ResultCode}");
+                    _transport.NetworkManager.LogError($"[ServerPeer] Failed to authenticate with EOS Connect. {authDataLogin.loginCallbackInfo?.ResultCode}");
                     base.SetLocalConnectionState(LocalConnectionState.Stopped, true);
                     yield break;
                 }
             }
 
-            if (_transport.NetworkManager.CanLog(LoggingType.Common))
-                Debug.Log($"[ServerPeer] Authenticated with EOS Connect. {EOS.LocalProductUserId}");
+            _transport.NetworkManager.Log($"[ServerPeer] Authenticated with EOS Connect. {EOS.LocalProductUserId}");
 
             // Attempt to Start Listening for Peer Connections...
             try
@@ -111,14 +108,11 @@ namespace FishNet.Transporting.FishyEOSPlugin
                 _acceptPeerConnectionsEventHandle = EOS.GetCachedP2PInterface().AddNotifyPeerConnectionRequest(
                     ref addNotifyPeerConnectionRequestOptions, null, OnPeerConnectionRequest);
 
-                if (_transport.NetworkManager.CanLog(LoggingType.Common))
-                    Debug.Log(
-                        $"[ServerPeer] Started listening for incoming connections. Handle #{_acceptPeerConnectionsEventHandle}");
+                _transport.NetworkManager.Log($"[ServerPeer] Started listening for incoming connections. Handle #{_acceptPeerConnectionsEventHandle}");
             }
             catch (Exception e)
             {
-                if (_transport.NetworkManager.CanLog(LoggingType.Error))
-                    Debug.LogError($"[ServerPeer] Failed to start listening for incoming connections. {e}");
+                _transport.NetworkManager.LogError($"[ServerPeer] Failed to start listening for incoming connections. {e}");
                 base.SetLocalConnectionState(LocalConnectionState.Stopped, true);
                 yield break;
             }
@@ -155,9 +149,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
             if (acceptConnectionResult != Result.Success)
             {
                 _clients.Remove(clientConnection);
-                if (_transport.NetworkManager.CanLog(LoggingType.Error))
-                    Debug.LogError(
-                        $"[ServerPeer] Failed to accept connection from {data.RemoteUserId} with handle #{data.SocketId} and connection id {nextId}. {acceptConnectionResult}");
+                _transport.NetworkManager.LogError($"[ServerPeer] Failed to accept connection from {data.RemoteUserId} with handle #{data.SocketId} and connection id {nextId}. {acceptConnectionResult}");
             }
         }
 
@@ -208,9 +200,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
 
             _transport.HandleRemoteConnectionState(new RemoteConnectionStateArgs(RemoteConnectionState.Started,
                 clientConnection.Id, _transport.Index));
-            if (_transport.NetworkManager.CanLog(LoggingType.Common))
-                Debug.Log(
-                    $"[ServerPeer.OnPeerConnectionEstablished] Established connection from {data.RemoteUserId} with handle #{data.SocketId} and connection id {clientConnection.Id}.");
+            _transport.NetworkManager.Log($"[ServerPeer.OnPeerConnectionEstablished] Established connection from {data.RemoteUserId} with handle #{data.SocketId} and connection id {clientConnection.Id}.");
         }
 
         /// <summary>
@@ -241,9 +231,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
 
             _transport.HandleRemoteConnectionState(new RemoteConnectionStateArgs(RemoteConnectionState.Stopped,
                 clientConnection.Value.Id, _transport.Index));
-            if (_transport.NetworkManager.CanLog(LoggingType.Common))
-                Debug.Log(
-                    $"[ServerPeer.OnPeerConnectionClosed] Closed connection from {data.RemoteUserId} with handle #{data.SocketId} and connection id {clientConnection.Value.Id}.");
+            _transport.NetworkManager.Log($"[ServerPeer.OnPeerConnectionClosed] Closed connection from {data.RemoteUserId} with handle #{data.SocketId} and connection id {clientConnection.Value.Id}.");
         }
 
         private void RemoveClosePeerConnectionHandle(string remoteUserId, ulong notificationId)
@@ -293,8 +281,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
             }
             catch (Exception e)
             {
-                if (_transport.NetworkManager.CanLog(LoggingType.Error))
-                    Debug.LogError($"[ServerPeer] Failed to stop listening for incoming connections. {e}");
+                _transport.NetworkManager.LogError($"[ServerPeer] Failed to stop listening for incoming connections. {e}");
                 base.SetLocalConnectionState(LocalConnectionState.Stopped, true);
                 return false;
             }
@@ -415,20 +402,17 @@ index++;
 
                 if (result == Result.NoConnection || result == Result.InvalidParameters)
                 {
-                    if (_transport.NetworkManager.CanLog(LoggingType.Common))
-                        Debug.Log($"Connection to {connectionId} was lost.");
+                    _transport.NetworkManager.Log($"Connection to {connectionId} was lost.");
                     StopConnection(connectionId);
                 }
                 else if (result != Result.Success)
                 {
-                    if (_transport.NetworkManager.CanLog(LoggingType.Error))
-                        Debug.LogError($"Could not send: {result.ToString()}");
+                    _transport.NetworkManager.LogError($"Could not send: {result}");
                 }
             }
             else
             {
-                if (_transport.NetworkManager.CanLog(LoggingType.Error))
-                    Debug.LogError($"ConnectionId {connectionId} does not exist, data will not be sent.");
+                _transport.NetworkManager.LogError($"ConnectionId {connectionId} does not exist, data will not be sent.");
             }
         }
 

--- a/FishNet/Plugins/FishyEOS/FishyEOS.cs
+++ b/FishNet/Plugins/FishyEOS/FishyEOS.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Epic.OnlineServices.P2P;
 using FishNet.Managing;
-using FishNet.Managing.Logging;
 using FishNet.Plugins.FishyEOS.Util;
 using UnityEngine;
 
@@ -407,8 +406,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
         {
             if (_server.GetLocalConnectionState() != LocalConnectionState.Stopped)
             {
-                if (NetworkManager.CanLog(LoggingType.Error))
-                    Debug.LogError("Server is already running.");
+                NetworkManager.LogError("Server is already running.");
                 return false;
             }
 
@@ -449,8 +447,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
             {
                 if (_client.GetLocalConnectionState() != LocalConnectionState.Stopped)
                 {
-                    if (NetworkManager.CanLog(LoggingType.Error))
-                        Debug.LogError("Client is already running.");
+                    NetworkManager.LogError("Client is already running.");
                     return false;
                 }
 


### PR DESCRIPTION
Updated logging to api breaking change in FishNet 4.0.7.
No need for CanLog() anymore.

NOTE: This might not work with versions prior to FishNet 4.0.7