### PR TITLE
Fixing Developer auth + Security fix

### DIFF
--- a/FishNet/Plugins/FishyEOS/FishyEOS.cs
+++ b/FishNet/Plugins/FishyEOS/FishyEOS.cs
@@ -301,7 +301,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
 
         public override bool IsLocalTransport(int connectionId)
         {
-            return true;
+            return false;
         }
 
         /// <summary>

--- a/FishNet/Plugins/FishyEOS/Util/Coroutines/ConnectLogin.cs
+++ b/FishNet/Plugins/FishyEOS/Util/Coroutines/ConnectLogin.cs
@@ -26,7 +26,8 @@ namespace FishNet.Plugins.FishyEOS.Util.Coroutines
                     Type = externalCredentialType
                 },
             };
-            if (!string.IsNullOrEmpty(displayName))
+			
+            //if (!string.IsNullOrEmpty(displayName))
                 loginOptions.UserLoginInfo = new UserLoginInfo { DisplayName = displayName };
             
             EOS.GetCachedConnectInterface().Login(ref loginOptions, null,


### PR DESCRIPTION
- Fixes FishyEOS transport bypassing several security checks by reporting to FishNet as a "local connection"
- Fixes Developer Authentication by submitting UserLoginInfo even if Display Name is null.