### PR TITLE
GetConnectionAddress fixes

### DIFF
--- a/FishNet/Plugins/FishyEOS/Core/ServerPeer.cs
+++ b/FishNet/Plugins/FishyEOS/Core/ServerPeer.cs
@@ -478,7 +478,7 @@ index++;
         internal string GetConnectionAddress(int connectionId)
         {
             var client = _clients.FirstOrDefault(x => x.Id == connectionId);
-            return client.LocalUserId.ToString();
+            return client.RemoteUserId.ToString();
         }
     }
 }

--- a/FishNet/Plugins/FishyEOS/Core/ServerPeer.cs
+++ b/FishNet/Plugins/FishyEOS/Core/ServerPeer.cs
@@ -215,7 +215,6 @@ namespace FishNet.Transporting.FishyEOSPlugin
                     continue;
                 
                 clientConnection = _clients[i];
-                _clients.Remove(clientConnection.Value);
             }
 
             if (!clientConnection.HasValue)
@@ -232,6 +231,8 @@ namespace FishNet.Transporting.FishyEOSPlugin
             _transport.HandleRemoteConnectionState(new RemoteConnectionStateArgs(RemoteConnectionState.Stopped,
                 clientConnection.Value.Id, _transport.Index));
             _transport.NetworkManager.Log($"[ServerPeer.OnPeerConnectionClosed] Closed connection from {data.RemoteUserId} with handle #{data.SocketId} and connection id {clientConnection.Value.Id}.");
+            
+            _clients.Remove(clientConnection.Value);
         }
 
         private void RemoveClosePeerConnectionHandle(string remoteUserId, ulong notificationId)

--- a/FishNet/Plugins/FishyEOS/FishyEOS.cs
+++ b/FishNet/Plugins/FishyEOS/FishyEOS.cs
@@ -136,6 +136,8 @@ namespace FishNet.Transporting.FishyEOSPlugin
         /// <returns></returns>
         public override string GetConnectionAddress(int connectionId)
         {
+            if (connectionId == CLIENT_HOST_ID)
+                return LocalProductUserId.ToString();
             return _server.GetConnectionAddress(connectionId);
         }
 


### PR DESCRIPTION
- fixed GetConnectionAddress for client host
- fixed GetConnectionAddress for server peer as suggested in [this issue](https://github.com/ETdoFresh/FishyEOS/commit/84863fe7928fc1e7f409aa0701b076b2b8bcc66b)
- fixed conn.GetAddress in ServerManager.OnRemoteConnectionState callback for a closed connection by removing it from ServerPeer._clients after triggering the callback.