### PR TITLE
Fix 'PredictedBullet' could not be found

### DIFF
--- a/FishNet/Plugins/FishyEOS/Samples~/EOS Lobby/RigidbodyPredictionNewInput/RigidbodyPredictionNewInput.cs
+++ b/FishNet/Plugins/FishyEOS/Samples~/EOS Lobby/RigidbodyPredictionNewInput/RigidbodyPredictionNewInput.cs
@@ -1,4 +1,5 @@
 ﻿using FishNet;
+using FishNet.Example.Prediction.Rigidbodies;
 using FishNet.Object;
 using FishNet.Object.Prediction;
 using FishNet.Transporting;


### PR DESCRIPTION
Hi,

I got an error message after importing the sample.

EOS Lobby Sample\RigidbodyPredictionNewInput\RigidbodyPredictionNewInput.cs(231,17): error CS0246: The type or namespace name 'PredictedBullet' could not be found (are you missing a using directive or an assembly reference?)