### PR TITLE
Update FishyEOS.cs

### DIFF
--- a/FishNet/Plugins/FishyEOS/FishyEOS.cs
+++ b/FishNet/Plugins/FishyEOS/FishyEOS.cs
@@ -503,7 +503,7 @@ namespace FishNet.Transporting.FishyEOSPlugin
         /// <returns></returns>
         public override int GetMTU(byte channel)
         {
-            return P2PInterface.MaxPacketSize;
+            return P2PInterface.MAX_PACKET_SIZE;
         }
 
         #endregion


### PR DESCRIPTION
Fixed the error where P2PInterface.MaxPacketSize doesnt exist, updated to P2PInterface.MAX_PACKET_SIZE to accommodate for the PlayEveryWare SDK Update v4.x